### PR TITLE
When Activity is not created - don't add listener

### DIFF
--- a/android/src/main/java/com/jrai/flutter_keyboard_visibility/FlutterKeyboardVisibilityPlugin.java
+++ b/android/src/main/java/com/jrai/flutter_keyboard_visibility/FlutterKeyboardVisibilityPlugin.java
@@ -38,7 +38,9 @@ public class FlutterKeyboardVisibilityPlugin implements FlutterPlugin, ActivityA
   public static void registerWith(PluginRegistry.Registrar registrar) {
     final FlutterKeyboardVisibilityPlugin plugin = new FlutterKeyboardVisibilityPlugin();
     plugin.init(registrar.messenger());
-    plugin.listenForKeyboard(registrar.activity());
+    if (registrar.activity() != null) {
+      plugin.listenForKeyboard(registrar.activity());
+    }
   }
 
   private void init(BinaryMessenger messenger) {


### PR DESCRIPTION
Safe access of nullable value.
When flutter engine registers plugins from e.g. Service then activity instance is not available.