### PR TITLE
Add KeyboardVisibilityBuilder

### DIFF
--- a/lib/flutter_keyboard_visibility.dart
+++ b/lib/flutter_keyboard_visibility.dart
@@ -188,6 +188,9 @@ class KeyboardDismissOnTap extends StatelessWidget {
   }
 }
 
+import 'package:flutter/widgets.dart';
+import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
+
 /// A convenience builder that exposes if the native keyboard is visible.
 class KeyboardVisibilityBuilder extends StatelessWidget {
   const KeyboardVisibilityBuilder({Key key, this.builder}) : super(key: key);
@@ -199,7 +202,7 @@ class KeyboardVisibilityBuilder extends StatelessWidget {
   Widget build(BuildContext context) {
     return StreamBuilder<bool>(
       stream: KeyboardVisibility.onChange,
-      initialData: false,
+      initialData: KeyboardVisibility.isVisible,
       builder: (context, snapshot) {
         final isKeyboardVisible = snapshot.data;
 

--- a/lib/flutter_keyboard_visibility.dart
+++ b/lib/flutter_keyboard_visibility.dart
@@ -187,3 +187,24 @@ class KeyboardDismissOnTap extends StatelessWidget {
     );
   }
 }
+
+/// A convenience builder that exposes if the native keyboard is visible.
+class KeyboardVisibilityBuilder extends StatelessWidget {
+  const KeyboardVisibilityBuilder({Key key, this.builder}) : super(key: key);
+
+  /// A builder method that exposes if the native keyboard is visible.
+  final Widget Function(BuildContext, bool isKeyboardVisible) builder;
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<bool>(
+      stream: KeyboardVisibility.onChange,
+      initialData: false,
+      builder: (context, snapshot) {
+        final isKeyboardVisible = snapshot.data;
+
+        return builder(context, isKeyboardVisible);
+      },
+    );
+  }
+}

--- a/lib/flutter_keyboard_visibility.dart
+++ b/lib/flutter_keyboard_visibility.dart
@@ -188,9 +188,6 @@ class KeyboardDismissOnTap extends StatelessWidget {
   }
 }
 
-import 'package:flutter/widgets.dart';
-import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
-
 /// A convenience builder that exposes if the native keyboard is visible.
 class KeyboardVisibilityBuilder extends StatelessWidget {
   const KeyboardVisibilityBuilder({Key key, this.builder}) : super(key: key);


### PR DESCRIPTION
This is an alternative method of handling Keyboard Visibility subscription that is pretty painless to use and matches many of the patterns found within the core Flutter library