### PR TITLE
4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ React to keyboard visibility changes.
 Add the dependency to your pubspec.yaml
 ```yaml
 dependencies:
-  flutter_keyboard_visibility: ^3.3.0
+  flutter_keyboard_visibility: ^4.0.0
 ```
 ## Usage: React to Keyboard Visibility Changes
 ### Option 1: Within your `Widget` tree using a builder
@@ -54,7 +54,7 @@ Widget build(BuildContext context) {
 ### Option 3: Direct query and subscription
 
 Query and/or subscribe to keyboard visibility directly with the  
-`KeyboardVisibility` class.
+`KeyboardVisibilityController` class.
 
 ```dart
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
@@ -62,11 +62,13 @@ import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 @override
 void initState() {
   super.initState();
+
+  var keyboardVisibilityController = KeyboardVisibilityController();
   // Query
-  print('Keyboard visibility direct query: ${KeyboardVisibility.isVisible}');
+  print('Keyboard visibility direct query: ${keyboardVisibilityController.isVisible}');
   
   // Subscribe
-  KeyboardVisibility.onChange.listen((bool visible) {
+  keyboardVisibilityController.listen((bool visible) {
     print('Keyboard visibility update. Is visible: ${visible}');
   });
 }

--- a/flutter_keyboard_visibility/CHANGELOG.md
+++ b/flutter_keyboard_visibility/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.0.1] - November 23, 2020
+
+* Update documentation
+
 ## [4.0.0] - November 23, 2020
 
 * Federated the plugin to better support more platforms going forward

--- a/flutter_keyboard_visibility/CHANGELOG.md
+++ b/flutter_keyboard_visibility/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [4.0.0] - November 23, 2020
+
+* Federated the plugin to better support more platforms going forward
+* Refactored internal implementation
+* Deprecated KeyboardVisibility static access, will be removed in a future release
+* Added KeyboardVisibilityController as a new way to access keyboard visibility
+* KeyboardVisibilityBuilder & KeyboardVisibilityProvider now have `controller` parameters that allow
+you to pass a mock implementation of KeyboardVisibilityController for testing.
+
 ## [3.3.0] - November 6, 2020
 
 Thanks to lukepighetti for this feature

--- a/flutter_keyboard_visibility/README.md
+++ b/flutter_keyboard_visibility/README.md
@@ -7,7 +7,7 @@ React to keyboard visibility changes.
 Add the dependency to your pubspec.yaml
 ```yaml
 dependencies:
-  flutter_keyboard_visibility: ^3.3.0
+  flutter_keyboard_visibility: ^4.0.0
 ```
 ## Usage: React to Keyboard Visibility Changes
 ### Option 1: Within your `Widget` tree using a builder
@@ -53,8 +53,8 @@ Widget build(BuildContext context) {
 
 ### Option 3: Direct query and subscription
 
-Query and/or subscribe to keyboard visibility directly with the  
-`KeyboardVisibility` class.
+Query and/or subscribe to keyboard visibility directly with the
+`KeyboardVisibilityController` class.
 
 ```dart
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
@@ -62,11 +62,13 @@ import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 @override
 void initState() {
   super.initState();
+
+  var keyboardVisibilityController = KeyboardVisibilityController();
   // Query
-  print('Keyboard visibility direct query: ${KeyboardVisibility.isVisible}');
-  
+  print('Keyboard visibility direct query: ${keyboardVisibilityController.isVisible}');
+
   // Subscribe
-  KeyboardVisibility.onChange.listen((bool visible) {
+  keyboardVisibilityController.listen((bool visible) {
     print('Keyboard visibility update. Is visible: ${visible}');
   });
 }
@@ -85,25 +87,12 @@ Widget build(BuildContext context) {
 }
 ```
 ## Testing
-Mock `MockKeyboardVisibilityController` and pass it to `KeyboardVisibilityBuilder` or `KeyboardVisibilityProvider`
+Call `KeyboardVisibility.setVisibilityForTesting(value)` to set a custom value to use during `flutter test`
 ```dart
 void main() {
   testWidgets('My Test', (WidgetTester tester) async {
-     // Pretend that the keyboard is visible.
-      var mockController = MockKeyboardVisibilityController();
-      when(mockController.onChange)
-          .thenAnswer((_) => Stream.fromIterable([true]));
-      when(mockController.isVisible).thenAnswer((_) => true);
-
-      await tester.pumpWidget(
-        KeyboardVisibilityBuilder(
-          controller: mockController,
-          builder: (_, _isKeyboardVisible) {
-            // _isKeyboardVisible is true!
-            return SizedBox();
-          },
-        ),
-      );
+    KeyboardVisibility.setVisibilityForTesting(true);
+    await tester.pumpWidget(MyApp());
   });
 }
 ```

--- a/flutter_keyboard_visibility/README.md
+++ b/flutter_keyboard_visibility/README.md
@@ -85,12 +85,25 @@ Widget build(BuildContext context) {
 }
 ```
 ## Testing
-Call `KeyboardVisibility.setVisibilityForTesting(value)` to set a custom value to use during `flutter test`
+Mock `MockKeyboardVisibilityController` and pass it to `KeyboardVisibilityBuilder` or `KeyboardVisibilityProvider`
 ```dart
 void main() {
   testWidgets('My Test', (WidgetTester tester) async {
-    KeyboardVisibility.setVisibilityForTesting(true);
-    await tester.pumpWidget(MyApp());
+     // Pretend that the keyboard is visible.
+      var mockController = MockKeyboardVisibilityController();
+      when(mockController.onChange)
+          .thenAnswer((_) => Stream.fromIterable([true]));
+      when(mockController.isVisible).thenAnswer((_) => true);
+
+      await tester.pumpWidget(
+        KeyboardVisibilityBuilder(
+          controller: mockController,
+          builder: (_, _isKeyboardVisible) {
+            // _isKeyboardVisible is true!
+            return SizedBox();
+          },
+        ),
+      );
   });
 }
 ```

--- a/flutter_keyboard_visibility/example/test/widget_test.dart
+++ b/flutter_keyboard_visibility/example/test/widget_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_keyboard_visibility_example/main.dart';
 
+// ignore_for_file: deprecated_member_use
+
 /// If [KeyboardVisibility.setVisibilityForTesting] is set we should not see
 /// a MissingPluginException logged
 void main() {

--- a/flutter_keyboard_visibility/example_old/test/widget_test.dart
+++ b/flutter_keyboard_visibility/example_old/test/widget_test.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:example_old/main.dart';
 
+// ignore_for_file: deprecated_member_use
+
 /// If [KeyboardVisibility.setVisibilityForTesting] is set we should not see
 /// a MissingPluginException logged
 void main() {

--- a/flutter_keyboard_visibility/lib/flutter_keyboard_visibility.dart
+++ b/flutter_keyboard_visibility/lib/flutter_keyboard_visibility.dart
@@ -1,6 +1,7 @@
 library flutter_keyboard_visibility;
 
 export 'package:flutter_keyboard_visibility/src/keyboard_visibility.dart';
+export 'package:flutter_keyboard_visibility/src/keyboard_visibility_controller.dart';
 export 'package:flutter_keyboard_visibility/src/ui/keyboard_visibility_provider.dart';
 export 'package:flutter_keyboard_visibility/src/ui/keyboard_visibility_builder.dart';
 export 'package:flutter_keyboard_visibility/src/ui/keyboard_dismiss_on_tap.dart';

--- a/flutter_keyboard_visibility/lib/src/keyboard_visibility.dart
+++ b/flutter_keyboard_visibility/lib/src/keyboard_visibility.dart
@@ -1,38 +1,24 @@
 import 'dart:async';
+import 'package:flutter_keyboard_visibility/src/keyboard_visibility_handler.dart';
 import 'package:meta/meta.dart';
-import 'package:flutter_keyboard_visibility_platform_interface/flutter_keyboard_visibility_platform_interface.dart';
 
 /// Provides access to the current keyboard visibility state and emits
 /// changes as they happen.
+@Deprecated(
+    'Use KeyboardVisibilityController instead. Will be removed in a future release.')
 class KeyboardVisibility {
   KeyboardVisibility._();
 
-  static FlutterKeyboardVisibilityPlatform get _platform =>
-      FlutterKeyboardVisibilityPlatform.instance;
-
-  static bool _isInitialized = false;
-  static final _onChangeController = StreamController<bool>();
-  static final _onChange = _onChangeController.stream.asBroadcastStream();
-
   /// Emits true every time the keyboard is shown, and false every time the
   /// keyboard is dismissed.
-  static Stream<bool> get onChange {
-    // If _testIsVisible set, don't try to create the EventChannel
-    if (!_isInitialized && _testIsVisible == null) {
-      _platform.onChange.listen(_updateValue);
-      _isInitialized = true;
-    }
-    return _onChange;
-  }
+  @Deprecated(
+      'Use KeyboardVisibilityController instead. Will be removed in a future release.')
+  static Stream<bool> get onChange => KeyboardVisibilityHandler.onChange;
 
   /// Returns true if the keyboard is currently visible, false if not.
-  static bool get isVisible => _testIsVisible ?? _isVisible;
-  static bool _isVisible = false;
-
-  /// Fake representation of whether or not the keyboard is visible
-  /// for testing purposes. When this value is non-null, it will be
-  /// reported exclusively by the `isVisible` getter.
-  static bool _testIsVisible;
+  @Deprecated(
+      'Use KeyboardVisibilityController instead. Will be removed in a future release.')
+  static bool get isVisible => KeyboardVisibilityHandler.isVisible;
 
   /// Forces `KeyboardVisibility` to report `isKeyboardVisible`
   /// for testing purposes.
@@ -40,14 +26,9 @@ class KeyboardVisibility {
   /// `KeyboardVisibility` will continue reporting `isKeyboardVisible`
   /// until the value is changed again with this method. To stop
   /// using fake values altogether, set `isKeyboardVisible` to null.
+  @Deprecated(
+      'Mock KeyboardVisibilityController instead. Will be removed in a future release.')
   @visibleForTesting
-  static void setVisibilityForTesting(bool isKeyboardVisible) {
-    _updateValue(isKeyboardVisible);
-  }
-
-  static void _updateValue(bool newValue) {
-    _isVisible = newValue;
-    _testIsVisible = newValue;
-    _onChangeController.add(newValue);
-  }
+  static void setVisibilityForTesting(bool isKeyboardVisible) =>
+      KeyboardVisibilityHandler.setVisibilityForTesting(isKeyboardVisible);
 }

--- a/flutter_keyboard_visibility/lib/src/keyboard_visibility_controller.dart
+++ b/flutter_keyboard_visibility/lib/src/keyboard_visibility_controller.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_keyboard_visibility/src/keyboard_visibility.dart';
+
+class KeyboardVisibilityController {
+  /// Constructs a singleton instance of [KeyboardVisibilityController].
+  ///
+  /// [KeyboardVisibilityController] is designed to work as a singleton.
+  // When a second instance is created, the first instance will not be able to listen to the
+  // EventChannel because it is overridden. Forcing the class to be a singleton class can prevent
+  // misuse of creating a second instance from a programmer.
+  factory KeyboardVisibilityController() {
+    _instance ??= KeyboardVisibilityController._();
+    return _instance;
+  }
+
+  KeyboardVisibilityController._();
+
+  static KeyboardVisibilityController _instance;
+
+  Stream<bool> get onChange => KeyboardVisibility.onChange;
+
+  bool get isVisible => KeyboardVisibility.isVisible;
+}

--- a/flutter_keyboard_visibility/lib/src/keyboard_visibility_controller.dart
+++ b/flutter_keyboard_visibility/lib/src/keyboard_visibility_controller.dart
@@ -1,5 +1,7 @@
-import 'package:flutter_keyboard_visibility/src/keyboard_visibility.dart';
+import 'package:flutter_keyboard_visibility/src/keyboard_visibility_handler.dart';
 
+/// Provides direct information about keyboard visibility and allows you
+/// to subscribe to changes.
 class KeyboardVisibilityController {
   /// Constructs a singleton instance of [KeyboardVisibilityController].
   ///
@@ -16,7 +18,7 @@ class KeyboardVisibilityController {
 
   static KeyboardVisibilityController _instance;
 
-  Stream<bool> get onChange => KeyboardVisibility.onChange;
+  Stream<bool> get onChange => KeyboardVisibilityHandler.onChange;
 
-  bool get isVisible => KeyboardVisibility.isVisible;
+  bool get isVisible => KeyboardVisibilityHandler.isVisible;
 }

--- a/flutter_keyboard_visibility/lib/src/keyboard_visibility_handler.dart
+++ b/flutter_keyboard_visibility/lib/src/keyboard_visibility_handler.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+import 'package:meta/meta.dart';
+import 'package:flutter_keyboard_visibility_platform_interface/flutter_keyboard_visibility_platform_interface.dart';
+
+/// Provides access to the current keyboard visibility state and emits
+/// changes as they happen.
+class KeyboardVisibilityHandler {
+  KeyboardVisibilityHandler._();
+
+  static FlutterKeyboardVisibilityPlatform get _platform =>
+      FlutterKeyboardVisibilityPlatform.instance;
+
+  static bool _isInitialized = false;
+  static final _onChangeController = StreamController<bool>();
+  static final _onChange = _onChangeController.stream.asBroadcastStream();
+
+  /// Emits true every time the keyboard is shown, and false every time the
+  /// keyboard is dismissed.
+  static Stream<bool> get onChange {
+    // If _testIsVisible set, don't try to create the EventChannel
+    if (!_isInitialized && _testIsVisible == null) {
+      _platform.onChange.listen(_updateValue);
+      _isInitialized = true;
+    }
+    return _onChange;
+  }
+
+  /// Returns true if the keyboard is currently visible, false if not.
+  static bool get isVisible => _testIsVisible ?? _isVisible;
+  static bool _isVisible = false;
+
+  /// Fake representation of whether or not the keyboard is visible
+  /// for testing purposes. When this value is non-null, it will be
+  /// reported exclusively by the `isVisible` getter.
+  static bool _testIsVisible;
+
+  /// Forces `KeyboardVisibility` to report `isKeyboardVisible`
+  /// for testing purposes.
+  ///
+  /// `KeyboardVisibility` will continue reporting `isKeyboardVisible`
+  /// until the value is changed again with this method. To stop
+  /// using fake values altogether, set `isKeyboardVisible` to null.
+  static void setVisibilityForTesting(bool isKeyboardVisible) {
+    _updateValue(isKeyboardVisible);
+  }
+
+  static void _updateValue(bool newValue) {
+    _isVisible = newValue;
+    _testIsVisible = newValue;
+    _onChangeController.add(newValue);
+  }
+}

--- a/flutter_keyboard_visibility/lib/src/keyboard_visibility_handler.dart
+++ b/flutter_keyboard_visibility/lib/src/keyboard_visibility_handler.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
-import 'package:meta/meta.dart';
 import 'package:flutter_keyboard_visibility_platform_interface/flutter_keyboard_visibility_platform_interface.dart';
 
 /// Provides access to the current keyboard visibility state and emits
-/// changes as they happen.
+/// changes as they happen. For internal use only.
 class KeyboardVisibilityHandler {
   KeyboardVisibilityHandler._();
 

--- a/flutter_keyboard_visibility/lib/src/ui/keyboard_visibility_builder.dart
+++ b/flutter_keyboard_visibility/lib/src/ui/keyboard_visibility_builder.dart
@@ -1,9 +1,18 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_keyboard_visibility/src/keyboard_visibility.dart';
+import 'package:flutter_keyboard_visibility/src/keyboard_visibility_controller.dart';
 
 /// A convenience builder that exposes if the native keyboard is visible.
 class KeyboardVisibilityBuilder extends StatelessWidget {
-  const KeyboardVisibilityBuilder({Key key, this.builder}) : super(key: key);
+  /// Optional: pass in a controller you already have created. This is useful
+  /// for testing, as you can pass in a mock instance. If no controller is
+  /// passed in, one will be created automatically.
+  final KeyboardVisibilityController controller;
+
+  KeyboardVisibilityController get _controller =>
+      controller ?? KeyboardVisibilityController();
+
+  const KeyboardVisibilityBuilder({Key key, this.builder, this.controller})
+      : super(key: key);
 
   /// A builder method that exposes if the native keyboard is visible.
   final Widget Function(BuildContext, bool isKeyboardVisible) builder;
@@ -11,8 +20,8 @@ class KeyboardVisibilityBuilder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<bool>(
-      stream: KeyboardVisibility.onChange,
-      initialData: KeyboardVisibility.isVisible,
+      stream: _controller.onChange,
+      initialData: _controller.isVisible,
       builder: (context, snapshot) {
         final isKeyboardVisible = snapshot.data;
 

--- a/flutter_keyboard_visibility/lib/src/ui/keyboard_visibility_provider.dart
+++ b/flutter_keyboard_visibility/lib/src/ui/keyboard_visibility_provider.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:flutter/widgets.dart';
-import 'package:flutter_keyboard_visibility/src/keyboard_visibility.dart';
+import 'package:flutter_keyboard_visibility/src/keyboard_visibility_controller.dart';
 
 /// Widget that reports to its descendants whether or not
 /// the keyboard is currently visible.
@@ -16,7 +16,7 @@ import 'package:flutter_keyboard_visibility/src/keyboard_visibility.dart';
 /// return KeyboardVisibilityProvider(
 ///   child: Builder(
 ///     builder: (BuildContext context) {
-///       final bool isKeyboardVisible = KeyboarVisibilityProvider.isKeyboardVisible(context);
+///       final bool isKeyboardVisible = KeyboardVisibilityProvider.isKeyboardVisible(context);
 ///
 ///       return Text('Keyboard is visible: $isKeyboardVisible');
 ///     },
@@ -24,6 +24,22 @@ import 'package:flutter_keyboard_visibility/src/keyboard_visibility.dart';
 /// );
 /// ```
 class KeyboardVisibilityProvider extends StatefulWidget {
+  final Widget child;
+
+  /// Optional: pass in a controller you already have created. This is useful
+  /// for testing, as you can pass in a mock instance. If no controller is
+  /// passed in, one will be created automatically.
+  final KeyboardVisibilityController controller;
+
+  KeyboardVisibilityController get _controller =>
+      controller ?? KeyboardVisibilityController();
+
+  const KeyboardVisibilityProvider({
+    Key key,
+    this.child,
+    this.controller,
+  }) : super(key: key);
+
   /// Returns `true` if the keyboard is currently visible, `false`
   /// if the keyboard is not currently visible, or `null` if
   /// the `flutter_keyboard_visibility` plugin does not yet
@@ -39,13 +55,6 @@ class KeyboardVisibilityProvider extends StatefulWidget {
         .isKeyboardVisible;
   }
 
-  const KeyboardVisibilityProvider({
-    Key key,
-    this.child,
-  }) : super(key: key);
-
-  final Widget child;
-
   @override
   _KeyboardVisibilityProviderState createState() =>
       _KeyboardVisibilityProviderState();
@@ -59,9 +68,9 @@ class _KeyboardVisibilityProviderState
   @override
   void initState() {
     super.initState();
-    _isKeyboardVisible = KeyboardVisibility.isVisible;
+    _isKeyboardVisible = widget._controller.isVisible;
     _subscription =
-        KeyboardVisibility.onChange.listen(_onKeyboardVisibilityChange);
+        widget._controller.onChange.listen(_onKeyboardVisibilityChange);
   }
 
   void _onKeyboardVisibilityChange(bool isKeyboardVisible) {

--- a/flutter_keyboard_visibility/pubspec.yaml
+++ b/flutter_keyboard_visibility/pubspec.yaml
@@ -2,17 +2,16 @@ name: flutter_keyboard_visibility
 description: Flutter plugin for discovering the state of the soft-keyboard visibility on Android and iOS.
 version: 4.0.0
 homepage: https://github.com/MisterJimson/flutter_keyboard_visibility
+repository: https://github.com/MisterJimson/flutter_keyboard_visibility
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.6"
+  flutter: ">=1.20.0"
 
 dependencies:
   meta: any
-  flutter_keyboard_visibility_platform_interface:
-    path: ../flutter_keyboard_visibility_platform_interface
-  flutter_keyboard_visibility_web:
-    path: ../flutter_keyboard_visibility_web
+  flutter_keyboard_visibility_platform_interface: ^1.0.0
+  flutter_keyboard_visibility_web: ^1.0.0
   flutter:
     sdk: flutter
 

--- a/flutter_keyboard_visibility/pubspec.yaml
+++ b/flutter_keyboard_visibility/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  mockito: ^4.1.3
   pedantic: 1.9.0
   flutter_test:
     sdk: flutter

--- a/flutter_keyboard_visibility/pubspec.yaml
+++ b/flutter_keyboard_visibility/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 
 dependencies:
   meta: any
-  flutter_keyboard_visibility_platform_interface: ^1.0.0
-  flutter_keyboard_visibility_web: ^1.0.0
+  flutter_keyboard_visibility_platform_interface: ^1.0.1
+  flutter_keyboard_visibility_web: ^1.0.1
   flutter:
     sdk: flutter
 

--- a/flutter_keyboard_visibility/pubspec.yaml
+++ b/flutter_keyboard_visibility/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  meta: any
+  meta: ">=1.0.0 <2.0.0"
   flutter_keyboard_visibility_platform_interface: ^1.0.1
   flutter_keyboard_visibility_web: ^1.0.1
   flutter:

--- a/flutter_keyboard_visibility/pubspec.yaml
+++ b/flutter_keyboard_visibility/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_keyboard_visibility
 description: Flutter plugin for discovering the state of the soft-keyboard visibility on Android and iOS.
-version: 4.0.0
+version: 4.0.1
 homepage: https://github.com/MisterJimson/flutter_keyboard_visibility
 repository: https://github.com/MisterJimson/flutter_keyboard_visibility
 

--- a/flutter_keyboard_visibility/test/flutter_keyboard_visibility_test.dart
+++ b/flutter_keyboard_visibility/test/flutter_keyboard_visibility_test.dart
@@ -121,7 +121,7 @@ void main() {
           .thenAnswer((_) => Stream.fromIterable([true]));
       when(mockController.isVisible).thenAnswer((_) => true);
 
-      // Build a Widget tree and query KeyboardVisibilityProvider
+      // Build a Widget tree and query KeyboardVisibilityBuilder
       // for the visibility of the keyboard.
       bool isKeyboardVisible;
 
@@ -135,7 +135,7 @@ void main() {
         ),
       );
 
-      // Verify that KeyboardVisibilityProvider reported that the
+      // Verify that KeyboardVisibilityBuilder reported that the
       // keyboard is visible.
       expect(isKeyboardVisible, true);
     });
@@ -148,7 +148,7 @@ void main() {
           .thenAnswer((_) => Stream.fromIterable([false]));
       when(mockController.isVisible).thenAnswer((_) => false);
 
-      // Build a Widget tree and query KeyboardVisibilityProvider
+      // Build a Widget tree and query KeyboardVisibilityBuilder
       // for the visibility of the keyboard.
       bool isKeyboardVisible;
 
@@ -162,7 +162,7 @@ void main() {
         ),
       );
 
-      // Verify that KeyboardVisibilityProvider reported that the
+      // Verify that KeyboardVisibilityBuilder reported that the
       // keyboard is visible.
       expect(isKeyboardVisible, false);
     });
@@ -176,7 +176,7 @@ void main() {
       when(mockController.onChange).thenAnswer((_) => streamController.stream);
       when(mockController.isVisible).thenAnswer((_) => true);
 
-      // Build a Widget tree with a KeyboardVisibilityProvider.
+      // Build a Widget tree with a KeyboardVisibilityBuilder.
       bool isKeyboardVisible;
 
       await tester.pumpWidget(
@@ -196,8 +196,6 @@ void main() {
       streamController.add(false);
       when(mockController.isVisible).thenAnswer((_) => false);
 
-      // Pump the tree to allow the InheritedWidget dependency to
-      // rebuild its descendants.
       await tester.pumpAndSettle();
 
       // Verify that our descendant rebuilt itself, and received the

--- a/flutter_keyboard_visibility/test/flutter_keyboard_visibility_test.dart
+++ b/flutter_keyboard_visibility/test/flutter_keyboard_visibility_test.dart
@@ -111,4 +111,98 @@ void main() {
       expect(isKeyboardVisible, false);
     });
   });
+
+  group('KeyboardVisibilityBuilder', () {
+    testWidgets('It reports true when the keyboard is visible',
+        (WidgetTester tester) async {
+      // Pretend that the keyboard is visible.
+      var mockController = MockKeyboardVisibilityController();
+      when(mockController.onChange)
+          .thenAnswer((_) => Stream.fromIterable([true]));
+      when(mockController.isVisible).thenAnswer((_) => true);
+
+      // Build a Widget tree and query KeyboardVisibilityProvider
+      // for the visibility of the keyboard.
+      bool isKeyboardVisible;
+
+      await tester.pumpWidget(
+        KeyboardVisibilityBuilder(
+          controller: mockController,
+          builder: (_, _isKeyboardVisible) {
+            isKeyboardVisible = _isKeyboardVisible;
+            return SizedBox();
+          },
+        ),
+      );
+
+      // Verify that KeyboardVisibilityProvider reported that the
+      // keyboard is visible.
+      expect(isKeyboardVisible, true);
+    });
+
+    testWidgets('It reports false when the keyboard is NOT visible',
+        (WidgetTester tester) async {
+      // Pretend that the keyboard is hidden.
+      var mockController = MockKeyboardVisibilityController();
+      when(mockController.onChange)
+          .thenAnswer((_) => Stream.fromIterable([false]));
+      when(mockController.isVisible).thenAnswer((_) => false);
+
+      // Build a Widget tree and query KeyboardVisibilityProvider
+      // for the visibility of the keyboard.
+      bool isKeyboardVisible;
+
+      await tester.pumpWidget(
+        KeyboardVisibilityBuilder(
+          controller: mockController,
+          builder: (_, _isKeyboardVisible) {
+            isKeyboardVisible = _isKeyboardVisible;
+            return SizedBox();
+          },
+        ),
+      );
+
+      // Verify that KeyboardVisibilityProvider reported that the
+      // keyboard is visible.
+      expect(isKeyboardVisible, false);
+    });
+
+    testWidgets('It rebuilds when the keyboard visibility changes',
+        (WidgetTester tester) async {
+      // Pretend that the keyboard is visible.
+      var mockController = MockKeyboardVisibilityController();
+      var streamController = StreamController<bool>();
+      streamController.add(true);
+      when(mockController.onChange).thenAnswer((_) => streamController.stream);
+      when(mockController.isVisible).thenAnswer((_) => true);
+
+      // Build a Widget tree with a KeyboardVisibilityProvider.
+      bool isKeyboardVisible;
+
+      await tester.pumpWidget(
+        KeyboardVisibilityBuilder(
+          controller: mockController,
+          builder: (_, _isKeyboardVisible) {
+            isKeyboardVisible = _isKeyboardVisible;
+            return SizedBox();
+          },
+        ),
+      );
+
+      // We expect that the keyboard is initially reported as visible.
+      expect(isKeyboardVisible, true);
+
+      // Pretend that the keyboard has gone from visible to hidden.
+      streamController.add(false);
+      when(mockController.isVisible).thenAnswer((_) => false);
+
+      // Pump the tree to allow the InheritedWidget dependency to
+      // rebuild its descendants.
+      await tester.pumpAndSettle();
+
+      // Verify that our descendant rebuilt itself, and received the
+      // updated visibility of the keyboard.
+      expect(isKeyboardVisible, false);
+    });
+  });
 }

--- a/flutter_keyboard_visibility_platform_interface/CHANGELOG.md
+++ b/flutter_keyboard_visibility_platform_interface/CHANGELOG.md
@@ -1,3 +1,3 @@
-## [1.0.0] - November 11, 2020
+## [1.0.0] - November 23, 2020
 
 * Initial interface

--- a/flutter_keyboard_visibility_platform_interface/CHANGELOG.md
+++ b/flutter_keyboard_visibility_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.1] - November 23, 2020
+
+* Documentation updates
+
 ## [1.0.0] - November 23, 2020
 
 * Initial interface

--- a/flutter_keyboard_visibility_platform_interface/LICENSE
+++ b/flutter_keyboard_visibility_platform_interface/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2006-2020
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/flutter_keyboard_visibility_platform_interface/README.md
+++ b/flutter_keyboard_visibility_platform_interface/README.md
@@ -1,0 +1,3 @@
+# Flutter Keyboard Visibility Platform Interface
+A common platform interface for the flutter_keyboard_visibility plugin.
+See the plugin [here](https://pub.dev/packages/flutter_keyboard_visibility);

--- a/flutter_keyboard_visibility_platform_interface/lib/flutter_keyboard_visibility_platform_interface.dart
+++ b/flutter_keyboard_visibility_platform_interface/lib/flutter_keyboard_visibility_platform_interface.dart
@@ -2,7 +2,9 @@ import 'dart:async';
 import 'package:flutter_keyboard_visibility_platform_interface/src/method_channel_flutter_keyboard_visibility.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+/// The platform interface for the flutter_keyboard_visibility plugin
 abstract class FlutterKeyboardVisibilityPlatform extends PlatformInterface {
+  /// The platform interface for the flutter_keyboard_visibility plugin
   FlutterKeyboardVisibilityPlatform() : super(token: _token);
 
   static final Object _token = Object();
@@ -23,6 +25,7 @@ abstract class FlutterKeyboardVisibilityPlatform extends PlatformInterface {
     _instance = instance;
   }
 
+  /// Emits changes to keyboard visibility from the platform
   Stream<bool> get onChange {
     throw UnimplementedError('get onChange has not been implemented.');
   }

--- a/flutter_keyboard_visibility_platform_interface/lib/src/method_channel_flutter_keyboard_visibility.dart
+++ b/flutter_keyboard_visibility_platform_interface/lib/src/method_channel_flutter_keyboard_visibility.dart
@@ -2,13 +2,17 @@ import 'package:flutter/services.dart';
 import 'package:flutter_keyboard_visibility_platform_interface/flutter_keyboard_visibility_platform_interface.dart';
 import 'package:meta/meta.dart';
 
+/// The method channel implementation of the flutter_keyboard_visibility plugin,
+/// currently used for Android and iOS.
 class MethodChannelFlutterKeyboardVisibility
     extends FlutterKeyboardVisibilityPlatform {
+  /// The event channel used for emitting keyboard visibility updates
   @visibleForTesting
   EventChannel eventChannel = EventChannel('flutter_keyboard_visibility');
 
   Stream<bool> _onKeyboardVisibilityChange;
 
+  /// Emits changes to keyboard visibility from the platform
   @override
   Stream<bool> get onChange {
     _onKeyboardVisibilityChange ??= eventChannel

--- a/flutter_keyboard_visibility_platform_interface/pubspec.yaml
+++ b/flutter_keyboard_visibility_platform_interface/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: any
+  meta: ">=1.0.0 <2.0.0"
   plugin_platform_interface: ^1.0.3
 
 dev_dependencies:

--- a/flutter_keyboard_visibility_platform_interface/pubspec.yaml
+++ b/flutter_keyboard_visibility_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_keyboard_visibility_platform_interface
 description: A common platform interface for the flutter_keyboard_visibility plugin.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/MisterJimson/flutter_keyboard_visibility
 repository: https://github.com/MisterJimson/flutter_keyboard_visibility
 

--- a/flutter_keyboard_visibility_web/CHANGELOG.md
+++ b/flutter_keyboard_visibility_web/CHANGELOG.md
@@ -1,3 +1,3 @@
-## [1.0.0] - November 11, 2020
+## [1.0.0] - November 23, 2020
 
 * Initial support so Flutter apps that run on web won't encounter errors. Visibility is returned as false.

--- a/flutter_keyboard_visibility_web/CHANGELOG.md
+++ b/flutter_keyboard_visibility_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.1] - November 23, 2020
+
+* Documentation updates
+
 ## [1.0.0] - November 23, 2020
 
 * Initial support so Flutter apps that run on web won't encounter errors. Visibility is returned as false.

--- a/flutter_keyboard_visibility_web/LICENSE
+++ b/flutter_keyboard_visibility_web/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2006-2020
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/flutter_keyboard_visibility_web/README.md
+++ b/flutter_keyboard_visibility_web/README.md
@@ -1,4 +1,6 @@
 # Flutter Keyboard Visibility Web
 Web support for Flutter Keyboard Visibility
+
+See the full plugin [here](https://pub.dev/packages/flutter_keyboard_visibility);
 ## Status
 Currently just returns false for visibility. In the future we would like to offer virtual keyboard detection.

--- a/flutter_keyboard_visibility_web/lib/flutter_keyboard_visibility_web.dart
+++ b/flutter_keyboard_visibility_web/lib/flutter_keyboard_visibility_web.dart
@@ -2,19 +2,22 @@ import 'dart:html' as html show window, Navigator;
 import 'package:flutter_keyboard_visibility_platform_interface/flutter_keyboard_visibility_platform_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-/// The web implementation of the [FlutterKeyboardVisibilityPlatform] of the FlutterKeyboardVisibility plugin.
+/// The web implementation of the [FlutterKeyboardVisibilityPlatform] of the
+/// FlutterKeyboardVisibility plugin.
 class FlutterKeyboardVisibilityPlugin
     extends FlutterKeyboardVisibilityPlatform {
   /// Constructs a [FlutterKeyboardVisibilityPlugin].
   FlutterKeyboardVisibilityPlugin(html.Navigator navigator);
 
-  /// Factory method that initializes the FlutterKeyboardVisibility plugin platform with an instance
-  /// of the plugin for the web.
+  /// Factory method that initializes the FlutterKeyboardVisibility plugin
+  /// platform with an instance of the plugin for the web.
   static void registerWith(Registrar registrar) {
     FlutterKeyboardVisibilityPlatform.instance =
         FlutterKeyboardVisibilityPlugin(html.window.navigator);
   }
 
+  /// Emits changes to keyboard visibility from the platform. Web is not
+  /// implemented yet so false is returned.
   @override
   Stream<bool> get onChange async* {
     yield false;

--- a/flutter_keyboard_visibility_web/lib/flutter_keyboard_visibility_web.dart
+++ b/flutter_keyboard_visibility_web/lib/flutter_keyboard_visibility_web.dart
@@ -2,13 +2,13 @@ import 'dart:html' as html show window, Navigator;
 import 'package:flutter_keyboard_visibility_platform_interface/flutter_keyboard_visibility_platform_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-/// The web implementation of the [FlutterKeyboardVisibilityPlatform] of the Battery plugin.
+/// The web implementation of the [FlutterKeyboardVisibilityPlatform] of the FlutterKeyboardVisibility plugin.
 class FlutterKeyboardVisibilityPlugin
     extends FlutterKeyboardVisibilityPlatform {
   /// Constructs a [FlutterKeyboardVisibilityPlugin].
   FlutterKeyboardVisibilityPlugin(html.Navigator navigator);
 
-  /// Factory method that initializes the Battery plugin platform with an instance
+  /// Factory method that initializes the FlutterKeyboardVisibility plugin platform with an instance
   /// of the plugin for the web.
   static void registerWith(Registrar registrar) {
     FlutterKeyboardVisibilityPlatform.instance =

--- a/flutter_keyboard_visibility_web/pubspec.yaml
+++ b/flutter_keyboard_visibility_web/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/MisterJimson/flutter_keyboard_visibility
 
 environment:
   sdk: ">=2.1.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.6"
+  flutter: ">=1.20.0"
 
 flutter:
   plugin:
@@ -16,8 +16,7 @@ flutter:
         fileName: flutter_keyboard_visibility_web.dart
 
 dependencies:
-  flutter_keyboard_visibility_platform_interface:
-    path: ../flutter_keyboard_visibility_platform_interface
+  flutter_keyboard_visibility_platform_interface: ^1.0.0
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/flutter_keyboard_visibility_web/pubspec.yaml
+++ b/flutter_keyboard_visibility_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_keyboard_visibility_web
 description: An implementation for the web platform of `flutter_keyboard_visibility'
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/MisterJimson/flutter_keyboard_visibility
 repository: https://github.com/MisterJimson/flutter_keyboard_visibility
 
@@ -16,7 +16,7 @@ flutter:
         fileName: flutter_keyboard_visibility_web.dart
 
 dependencies:
-  flutter_keyboard_visibility_platform_interface: ^1.0.0
+  flutter_keyboard_visibility_platform_interface: ^1.0.1
   flutter_web_plugins:
     sdk: flutter
   flutter:


### PR DESCRIPTION
* Federated the plugin to better support more platforms going forward
* Refactored internal implementation
* Deprecated KeyboardVisibility static access, will be removed in a future release Fixes #21 
* Added KeyboardVisibilityController as a new way to access keyboard visibility
* KeyboardVisibilityBuilder & KeyboardVisibilityProvider now have `controller` parameters that allow
you to pass a mock implementation of KeyboardVisibilityController for testing.

Progress towards #22, but not enough to close yet.
Progress towards #10, but not enough to close yet.