### PR TITLE
Swap jcenter with mavenCentral, and update Gradle versions

### DIFF
--- a/flutter_keyboard_visibility/android/build.gradle
+++ b/flutter_keyboard_visibility/android/build.gradle
@@ -4,18 +4,18 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.4'
+        classpath 'com.android.tools.build:gradle:7.0.0'
     }
 }
 
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/flutter_keyboard_visibility/example/android/build.gradle
+++ b/flutter_keyboard_visibility/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/flutter_keyboard_visibility/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_keyboard_visibility/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip


### PR DESCRIPTION
This PR updates the gradle versions to more current values while also replacing jcenter with mavenCentral as jcenter is reaching EOL shortly.