### PR TITLE
Added Android 11 API and workaround for android tv

### DIFF
--- a/flutter_keyboard_visibility/android/src/main/java/com/jrai/flutter_keyboard_visibility/FlutterKeyboardVisibilityPlugin.java
+++ b/flutter_keyboard_visibility/android/src/main/java/com/jrai/flutter_keyboard_visibility/FlutterKeyboardVisibilityPlugin.java
@@ -5,6 +5,7 @@ import android.graphics.Rect;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewTreeObserver;
+import androidx.core.view.WindowInsetsCompat;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -70,9 +71,15 @@ public class FlutterKeyboardVisibilityPlugin implements FlutterPlugin, ActivityA
       Rect r = new Rect();
       mainView.getWindowVisibleDisplayFrame(r);
 
-      // check if the visible part of the screen is less than 85%
-      // if it is then the keyboard is showing
-      boolean newState = ((double)r.height() / (double)mainView.getRootView().getHeight()) < 0.85;
+      boolean newState = false;
+
+      if (android.os.Build.VERSION.SDK_INT >= 30){
+        newState = mainView.getRootWindowInsets().isVisible(WindowInsetsCompat.Type.ime());
+      } else{
+        // check if the visible part of the screen is less than 85%
+        // if it is then the keyboard is showing
+        newState = ((double)r.height() / (double)mainView.getRootView().getHeight()) < 0.85;
+      }
 
       if (newState != isVisible) {
         isVisible = newState;


### PR DESCRIPTION
Android 11 has a better API to check if the keyboard is visible or not.
I have implemented it and now it is possible to check if the keyboard is visible on android tv.