### PR TITLE
ios: remove unnecessary CoreLocation import

### DIFF
--- a/flutter_keyboard_visibility/CHANGELOG.md
+++ b/flutter_keyboard_visibility/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [5.4.1] - March 26, 2023
+
+* Fixed `NSLocationWhenInUseUsageDescription` warning on iOS
+
 ## [5.4.0] - October 4, 2022
 Thanks to cbenhagen for this feature
 

--- a/flutter_keyboard_visibility/ios/Classes/FlutterKeyboardVisibilityPlugin.m
+++ b/flutter_keyboard_visibility/ios/Classes/FlutterKeyboardVisibilityPlugin.m
@@ -8,8 +8,6 @@
 
 #import "FlutterKeyboardVisibilityPlugin.h"
 
-@import CoreLocation;
-
 @interface FlutterKeyboardVisibilityPlugin() <FlutterStreamHandler>
 
 @property (copy, nonatomic) FlutterEventSink flutterEventSink;

--- a/flutter_keyboard_visibility/pubspec.yaml
+++ b/flutter_keyboard_visibility/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_keyboard_visibility
 description: Flutter plugin for discovering the state of the soft-keyboard visibility on Android and iOS.
-version: 5.4.0
+version: 5.4.1
 homepage: https://github.com/MisterJimson/flutter_keyboard_visibility
 repository: https://github.com/MisterJimson/flutter_keyboard_visibility
 


### PR DESCRIPTION
This fixes #127 `NSLocationWhenInUseUsageDescription` warning