### PR TITLE
Add support to Gradle 8+

### DIFF
--- a/flutter_keyboard_visibility/CHANGELOG.md
+++ b/flutter_keyboard_visibility/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [5.4.2] - UNRELEASED
+Thanks to davidmartos96 for help with this release
 
 * Add compatibility with AGP 8 (Android Gradle Plugin).
 * Removed implicit-casts lint warning as it's no longer supported
-
 
 ## [5.4.1] - March 26, 2023
 

--- a/flutter_keyboard_visibility/CHANGELOG.md
+++ b/flutter_keyboard_visibility/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [5.4.2] - UNRELEASED
 
 * Add compatibility with AGP 8 (Android Gradle Plugin).
+* Removed implicit-casts lint warning as it's no longer supported
 
 
 ## [5.4.1] - March 26, 2023

--- a/flutter_keyboard_visibility/CHANGELOG.md
+++ b/flutter_keyboard_visibility/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.4.2] - UNRELEASED
+
+* Add compatibility with AGP 8 (Android Gradle Plugin).
+
+
 ## [5.4.1] - March 26, 2023
 
 * Fixed `NSLocationWhenInUseUsageDescription` warning on iOS

--- a/flutter_keyboard_visibility/analysis_options.yaml
+++ b/flutter_keyboard_visibility/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  strong-mode:
-    implicit-casts: false

--- a/flutter_keyboard_visibility/android/build.gradle
+++ b/flutter_keyboard_visibility/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:8.0.1'
     }
 }
 
@@ -22,6 +22,11 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.jrai.flutter_keyboard_visibility'
+    }
+
     compileSdkVersion 31
 
     defaultConfig {

--- a/flutter_keyboard_visibility/android/build.gradle
+++ b/flutter_keyboard_visibility/android/build.gradle
@@ -32,7 +32,13 @@ android {
     defaultConfig {
         minSdkVersion 16
     }
-    lintOptions {
+
+    lint {
         disable 'InvalidPackage'
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }

--- a/flutter_keyboard_visibility/example/analysis_options.yaml
+++ b/flutter_keyboard_visibility/example/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  strong-mode:
-    implicit-casts: false

--- a/flutter_keyboard_visibility/example/android/app/build.gradle
+++ b/flutter_keyboard_visibility/example/android/app/build.gradle
@@ -26,6 +26,8 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
+    namespace 'com.jrai.flutter_keyboard_visibility_example.example'
+
     compileSdkVersion 31
 
     compileOptions {

--- a/flutter_keyboard_visibility/example/android/app/src/debug/AndroidManifest.xml
+++ b/flutter_keyboard_visibility/example/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.jrai.flutter_keyboard_visibility_example.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/flutter_keyboard_visibility/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter_keyboard_visibility/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.jrai.flutter_keyboard_visibility_example.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
    <application
         android:label="example"
         android:icon="@mipmap/ic_launcher">

--- a/flutter_keyboard_visibility/example/android/app/src/profile/AndroidManifest.xml
+++ b/flutter_keyboard_visibility/example/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.jrai.flutter_keyboard_visibility_example.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/flutter_keyboard_visibility/example/android/build.gradle
+++ b/flutter_keyboard_visibility/example/android/build.gradle
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/flutter_keyboard_visibility/example/android/build.gradle
+++ b/flutter_keyboard_visibility/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.8.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0'
+        classpath 'com.android.tools.build:gradle:8.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/flutter_keyboard_visibility/example/android/gradle.properties
+++ b/flutter_keyboard_visibility/example/android/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/flutter_keyboard_visibility/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_keyboard_visibility/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip

--- a/flutter_keyboard_visibility/pubspec.yaml
+++ b/flutter_keyboard_visibility/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_keyboard_visibility
 description: Flutter plugin for discovering the state of the soft-keyboard visibility on Android and iOS.
-version: 5.4.1
+version: 5.4.2
 homepage: https://github.com/MisterJimson/flutter_keyboard_visibility
 repository: https://github.com/MisterJimson/flutter_keyboard_visibility
 

--- a/flutter_keyboard_visibility_linux/analysis_options.yaml
+++ b/flutter_keyboard_visibility_linux/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  strong-mode:
-    implicit-casts: false

--- a/flutter_keyboard_visibility_macos/analysis_options.yaml
+++ b/flutter_keyboard_visibility_macos/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  strong-mode:
-    implicit-casts: false

--- a/flutter_keyboard_visibility_platform_interface/analysis_options.yaml
+++ b/flutter_keyboard_visibility_platform_interface/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  strong-mode:
-    implicit-casts: false

--- a/flutter_keyboard_visibility_web/analysis_options.yaml
+++ b/flutter_keyboard_visibility_web/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  strong-mode:
-    implicit-casts: false

--- a/flutter_keyboard_visibility_windows/analysis_options.yaml
+++ b/flutter_keyboard_visibility_windows/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  strong-mode:
-    implicit-casts: false


### PR DESCRIPTION
## Description

Hello, currently the plugin doesn't build when Gradle 8+ is used. That is because the property `namespace` is mandatory.

* I updated the Android example project.
* I included the namespace property with backwards compatibility