### PR TITLE
Rename lint into lintOptions

### DIFF
--- a/flutter_keyboard_visibility/CHANGELOG.md
+++ b/flutter_keyboard_visibility/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [5.4.4] - Jun 29, 2023
+* Fixed compatibility with Gradle 7 Android projects.
+
 ## [5.4.3] - May 20, 2023
 Thanks to fabricio-godoi for reporting this issue.
 

--- a/flutter_keyboard_visibility/android/build.gradle
+++ b/flutter_keyboard_visibility/android/build.gradle
@@ -33,7 +33,7 @@ android {
         minSdkVersion 16
     }
 
-    lint {
+    lintOptions {
         disable 'InvalidPackage'
     }
 

--- a/flutter_keyboard_visibility/pubspec.yaml
+++ b/flutter_keyboard_visibility/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_keyboard_visibility
 description: Flutter plugin for discovering the state of the soft-keyboard visibility on Android and iOS.
-version: 5.4.3
+version: 5.4.4
 homepage: https://github.com/MisterJimson/flutter_keyboard_visibility
 repository: https://github.com/MisterJimson/flutter_keyboard_visibility
 


### PR DESCRIPTION
Fixes #136

It appears that using the new keyword `lint` instead of `lintOptions` can break old AGP. Probably because it was deprecated in AGP 7.2

What I did is to bring back the original name. Official packages seem to be relying on the old keyword as well https://github.com/flutter/packages/blob/f8931024c4cb4ee0631527f11c2b6d4e2c1b65bc/packages/camera/camera_android/android/build.gradle#L40

Just to be sure I've also run the counter app with Flutter 2.8.0 which uses AGP 4.1.0 and is working fine now. 
If you want to try it an old version of Android Studio is required. I've used Android Studio Dolphin 2021.3.1.