### PR TITLE
change compileSdkVersion from 31 to flutter default

### DIFF
--- a/flutter_keyboard_visibility/android/build.gradle
+++ b/flutter_keyboard_visibility/android/build.gradle
@@ -27,7 +27,7 @@ android {
         namespace 'com.jrai.flutter_keyboard_visibility'
     }
 
-    compileSdkVersion 31
+    compileSdkVersion flutter.compileSdkVersion
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
To overcome a bug in flutter https://github.com/flutter/flutter/issues/63533 that sets the android sdk version to the lowest version used by any plugin, I am suggesting to update the android compileSdkVersion to the flutter default.

Without this, every project using your plugin ends up in compiling against android sdk 31