### PR TITLE
[flutter_keyboard_visibility_web] Add WASM support.

### DIFF
--- a/flutter_keyboard_visibility_web/CHANGELOG.md
+++ b/flutter_keyboard_visibility_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.1.0] - June 23, 2025
+
+* Migrates to `package:web` to support WASM.
+
 ## [2.0.0] - March 4, 2021
 
 * Migrated to null safety

--- a/flutter_keyboard_visibility_web/lib/flutter_keyboard_visibility_web.dart
+++ b/flutter_keyboard_visibility_web/lib/flutter_keyboard_visibility_web.dart
@@ -1,4 +1,4 @@
-import 'dart:html' as html show window, Navigator;
+import 'package:web/web.dart' as web show window, Navigator;
 import 'package:flutter_keyboard_visibility_platform_interface/flutter_keyboard_visibility_platform_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
@@ -7,13 +7,13 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 class FlutterKeyboardVisibilityPluginWeb
     extends FlutterKeyboardVisibilityPlatform {
   /// Constructs a [FlutterKeyboardVisibilityPluginWeb].
-  FlutterKeyboardVisibilityPluginWeb(html.Navigator navigator);
+  FlutterKeyboardVisibilityPluginWeb(web.Navigator navigator);
 
   /// Factory method that initializes the FlutterKeyboardVisibility plugin
   /// platform with an instance of the plugin for the web.
   static void registerWith(Registrar registrar) {
     FlutterKeyboardVisibilityPlatform.instance =
-        FlutterKeyboardVisibilityPluginWeb(html.window.navigator);
+        FlutterKeyboardVisibilityPluginWeb(web.window.navigator);
   }
 
   /// Emits changes to keyboard visibility from the platform. Web is not

--- a/flutter_keyboard_visibility_web/pubspec.yaml
+++ b/flutter_keyboard_visibility_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_keyboard_visibility_web
 description: An implementation for the web platform of `flutter_keyboard_visibility'
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/MisterJimson/flutter_keyboard_visibility
 repository: https://github.com/MisterJimson/flutter_keyboard_visibility
 
@@ -21,6 +21,7 @@ dependencies:
     sdk: flutter
   flutter:
     sdk: flutter
+  web: ">=0.5.1 <2.0.0"
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
Fixes https://github.com/MisterJimson/flutter_keyboard_visibility/issues/150

### Description
- Migrates to `package:web` to support WASM
